### PR TITLE
fix #34

### DIFF
--- a/gorazor/cases/bug34.gohtml
+++ b/gorazor/cases/bug34.gohtml
@@ -1,0 +1,1 @@
+value=\"<?= h(aabasdf\Admin\Document::$asdf) ?>\"/>\n

--- a/gorazor/gogen.go
+++ b/gorazor/gogen.go
@@ -74,13 +74,14 @@ func (self *Compiler) genPart() {
 	for _, p := range self.parts {
 		if p.ptype == CMKP && p.value != "" {
 			// do some escapings
-			p.value = strings.Replace(p.value, `\n`, `\\n`, -1)
-			p.value = strings.Replace(p.value, "\n", `\n`, -1)
-			p.value = strings.Replace(p.value, `"`, `\"`, -1)
-			for strings.HasSuffix(p.value, "\\n") {
-				p.value = p.value[:len(p.value)-2]
+			for strings.HasSuffix(p.value, "\n") {
+				p.value = p.value[:len(p.value)-1]
 			}
-			if p.value != "\\n" && p.value != "" {
+			p.value = fmt.Sprintf("%#v", p.value)
+			p.value = p.value[1 : len(p.value)-1]
+			p.value = strings.Replace(p.value, `\t`, "\t", -1)
+
+			if p.value != `\n` && p.value != "" {
 				res += "_buffer.WriteString(\"" + p.value + "\")\n"
 			}
 		} else if p.ptype == CBLK {

--- a/gorazor/test/bug34.go
+++ b/gorazor/test/bug34.go
@@ -1,0 +1,12 @@
+package cases
+
+import (
+	"bytes"
+)
+
+func Bug34() string {
+	var _buffer bytes.Buffer
+	_buffer.WriteString("value=\\\"<?= h(aabasdf\\Admin\\Document::$asdf) ?>\\\"/>\\n")
+
+	return _buffer.String()
+}


### PR DESCRIPTION
使用`fmt.Sprintf("%#v",p.value)`来转义各种字符串 来修复 #34 .
Use `fmt.Sprintf("%#v",p.value)` to do the escape thing to fix the #34 .