### PR TITLE
make error report more friendly.

### DIFF
--- a/gorazor/gogen.go
+++ b/gorazor/gogen.go
@@ -409,7 +409,7 @@ func run(path string, Options Option) (*Compiler, error) {
 	parser := &Parser{&Ast{}, nil, res, []Token{}, false, UNK}
 	err = parser.Run()
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(path, ":", err)
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
Make the error report more friendly.
```
src/xxxx.gohtml : Unmatched tag close: "(" at line: 41 pos: 24
```