### PR TITLE
check if layout is necessary

### DIFF
--- a/gorazor/gogen.go
+++ b/gorazor/gogen.go
@@ -322,6 +322,9 @@ func (cp *Compiler) processLayout() {
 		parts := strings.SplitN(cp.layout, "/", -1)
 		base := Capitalize(parts[len(parts)-1])
 		foot += "layout." + base + "("
+	} else if len(sections) > 0 {
+		fmt.Println("expect layout for sections")
+		os.Exit(1)
 	}
 	foot += "_buffer.String()"
 	args := LayoutArgs(cp.layout)


### PR DESCRIPTION
当源文件中存在 section 却不存在 layout 时，gorazor 将会生成错误的代码，但不会报错。
例如：
```
@{}
@section header{
}
```
将会生成这样的错误代码：
```go
package examples

import (
	"bytes"
)

func A() string {
	var _buffer bytes.Buffer

	header := func() string {
		var _buffer bytes.Buffer
		return _buffer.String()
	}

	return _buffer.String(), header()
}
```
由于 layout 的缺失，其真实的返回值类型函数签名中的返回值类型不一致。

实际上像这种情况应该要报错并且终止代码生成。